### PR TITLE
Runner When Parsing -o Arguments Now Captures the Options Correctly

### DIFF
--- a/automator.cpp
+++ b/automator.cpp
@@ -125,7 +125,7 @@ void Automator::wait(int timeout) {
 QObject *Automator::findObject(QString objectName)
 {
     QObjectList list = findObjects(objectName);
-    QObject* res = 0;
+    QObject* res = nullptr;
 
     if (list.size() > 0) {
         res = list.first();
@@ -235,10 +235,8 @@ bool Automator::click(QQuickItem *item, int delay,  QPointF pt)
 
     QPointF hit;
     if (pt.isNull()) {
-        int w = item->width();
-        int h = item->height();
-        int cx =  w /2;
-        int cy =  h / 2;
+        int cx =  static_cast<int>(item->width()) /2;
+        int cy =  static_cast<int>(item->height()) / 2;
         hit = item->mapToScene(QPointF(cx,cy));
     } else {
         hit = item->mapToScene(pt);
@@ -254,7 +252,7 @@ bool Automator::click(QQuickItem *item, int delay,  QPointF pt)
 bool Automator::click(QQuickItem *item, QString childObjectName)
 {
     QObjectList list = findObjects(item, childObjectName);
-    QQuickItem* child = 0;
+    QQuickItem* child = nullptr;
 
     if (list.size() == 0) {
         return false;
@@ -366,7 +364,7 @@ QObject* Automator::obtainSingletonObject(QString package, int versionMajor, int
 
     QString qml = pattern.arg(package).arg(versionMajor).arg(versionMinor).arg(typeName);
 
-    QObject* holder = 0;
+    QObject* holder = nullptr;
 
     QQmlComponent comp (m_engine.data());
     comp.setData(qml.toUtf8(),QUrl());
@@ -375,7 +373,7 @@ QObject* Automator::obtainSingletonObject(QString package, int versionMajor, int
     if (!holder) {
         qWarning() << QString("Testable: Failed to gain singleton object: %1").arg(typeName);
         qWarning() << QString("Error: ") << comp.errorString();
-        return 0;
+        return nullptr;
     }
 
     QObject* object = holder->property("object").value<QObject*>();

--- a/testrunner.cpp
+++ b/testrunner.cpp
@@ -4,19 +4,21 @@
 #include <QMetaMethod>
 #include <QPointer>
 #include <QCommandLineParser>
+#include <QTemporaryFile>
+#include <QVector>
 #include "testrunner.h"
 #include "automator.h"
 #include "priv/objectutils.h"
 
-static TestRunner *m_defaultInstance = 0;
+static TestRunner *m_defaultInstance = nullptr;
 
 TestRunner::TestRunner()
 {
-    if (m_defaultInstance == 0) {
+    if (m_defaultInstance == nullptr) {
         m_defaultInstance = this;
     }
 
-    m_engineHook = 0;
+    m_engineHook = nullptr;
 }
 
 TestRunner::~TestRunner()
@@ -33,7 +35,7 @@ TestRunner::~TestRunner()
     m_testObjects.clear();
 
     if (m_defaultInstance == this) {
-        m_defaultInstance = 0;
+        m_defaultInstance = nullptr;
     }
 }
 
@@ -52,15 +54,42 @@ bool TestRunner::exec(QStringList arguments)
 {
     m_arguments = arguments;
 
+    int indexOfOutFile = -1;
+    for(int index = 0; index < m_arguments.size();  ++index) {
+         if (m_arguments[index].indexOf("-o") == 0)
+         {
+             indexOfOutFile = index+1;
+             break;
+         }
+    }
+
+    QFileInfo outputFile;
+    QString outputFileExt;
+    QString path;
+    if(indexOfOutFile != -1)
+    {
+        outputFile.setFile(arguments[indexOfOutFile]);
+        outputFileExt = outputFile.completeSuffix();
+        path = outputFile.path() + QDir::separator() + outputFile.baseName() +"_";
+
+    }
+    QStringList outputfiles;
+    outputfiles.reserve(m_testObjects.size());
     QObject *object;
     QVariant item;
     bool error = false;
 
     foreach (item,m_testObjects) {
         object = item.value<QObject*>();
+        if(indexOfOutFile != -1)
+        {
+
+            QString uniquePath ( (object) ? object->metaObject()->className() :  "QuickTests");
+            m_arguments[indexOfOutFile] = path + uniquePath + "."+outputFileExt;
+        }
         if (object) {
             error |= run(object, m_arguments);
-        } else if (item.type() == (int) QMetaType::QString) {
+        } else if (item.type() == static_cast<int>(QMetaType::QString)) {
             error |= run(item.toString(), m_arguments);
         }
     }
@@ -93,11 +122,18 @@ bool TestRunner::run(QObject *object, const QStringList& arguments)
     params << executable;
 
     QStringList tmp;
-
     // Always add "-*" to params.
+    bool addNext = false;
     foreach (QString arg, args) {
-        if (arg.indexOf("-") == 0) {
+        //-o options pramaters are stored in the next arg
+        if (arg.indexOf("-o") == 0) {
+             params << arg;
+             addNext = true;
+             continue;
+        }
+        else if (arg.indexOf("-") == 0 || addNext) {
             params << arg;
+            addNext = false;
         } else {
             tmp << arg;
         }
@@ -136,8 +172,14 @@ bool TestRunner::run(QString path, const QStringList &arguments)
     QStringList testcases = arguments.filter(QRegExp("::"));
 
     QStringList nonOptionArgs; // Filter all "-" parameter
+
+    bool addNext = false;
     foreach (QString arg, args) {
-        if (arg.indexOf("-") != 0) {
+        if (arg.indexOf("-o") == 0 || addNext == true) {
+             addNext = !addNext;
+             continue;
+        }
+        else if (arg.indexOf("-") != 0) {
             nonOptionArgs << arg;
         }
     }
@@ -151,7 +193,7 @@ bool TestRunner::run(QString path, const QStringList &arguments)
     paths << path;
     paths << m_importPaths;
 
-    char **s = (char**) malloc(sizeof(char*) * (10 + args.size() + paths.size() * 2));
+    char **s = static_cast<char**>( malloc(sizeof(char*) * static_cast<size_t>((10 + args.size() + paths.size() * 2))));
     int idx = 0;
     s[idx++] = executable.toUtf8().data();
 
@@ -163,7 +205,7 @@ bool TestRunner::run(QString path, const QStringList &arguments)
     foreach( QString arg,args) {
         s[idx++] = strdup(arg.toUtf8().data());
     }
-    s[idx++] = 0;
+    s[idx++] = nullptr;
 
     const char *name = "QuickTests";
     const char *source = strdup(path.toUtf8().data());
@@ -187,7 +229,7 @@ void TestRunner::setConfig(const QVariantMap &config)
 
 void TestRunner::execEngineHook(QQmlEngine *engine)
 {
-    if (m_engineHook != 0) {
+    if (m_engineHook != nullptr) {
         m_engineHook(engine);
     }
 }


### PR DESCRIPTION
Example: two test cases classes in C++ called test1 test2 using the arguments
-o ./testResult.xml -xml
would produce
./testResult_test1.xml
and
./testResult_test2.xml

Any qml will test will produce one ./testResult_QuickTest.xml file